### PR TITLE
本体の仕様変更に追従（ナビの定義の構造変更・ファイル名変更）

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ class Event implements EventSubscriberInterface
 ### 管理画面ナビの拡張
 
 管理画面にプラグインのメニューを追加します。
-以下のようにEccubeNavを実装すると, 対象メニュー内の最下部に追加されます。
+以下のようにEccubeNavを実装すると, メニューの上書き/追加ができます。
+追加の場合は対象メニュー内の最下部に追加されます。
+構造は本体のナビ定義も参考にしてください。
 プラグインの場合、有効時のみ表示されます。
 
 ```php
@@ -172,10 +174,42 @@ class Nav implements EccubeNav
     public static function getNav()
     {
         return [
-            'order' => [
-                'id' => 'sample_payment_admin_payment_status',
-                'name' => 'sample_payment.admin.nav.payment_list',
-                'url' => 'sample_payment_admin_payment_status',
+            'product' => [
+                'name' => '商品管理（上書き）',
+                'child' => [
+                    'product_master' => [
+                        'name' => '商品一覧（上書き）',
+                        'url' => 'admin_homepage',
+                    ],
+                    'hoge' => [
+                        'name' => '商品管理の子（追加）',
+                        'url' => 'admin_homepage',
+                    ],
+                ]
+            ],
+            'piyo' => [
+                'name' => '1階層メニュー（追加）',
+                'url' => 'admin_homepage',
+                'icon' => 'fa-cube',
+                'child' => [
+                    'piyopiyo1' => [
+                        'name' => '2階層メニュー（子なし）',
+                        'url' => 'admin_homepage',
+                    ],
+                    'piyopiyo2' => [
+                        'name' => '2階層メニュー（子あり）',
+                        'child' => [
+                            'piyopiyopiyo1' => [
+                                'name' => '2階層メニュー1',
+                                'url' => 'admin_homepage',
+                            ],
+                            'piyopiyopiyo2' => [
+                                'name' => '2階層メニュー2',
+                                'url' => 'admin_homepage',
+                            ],
+                        ],
+                    ],
+                ],
             ],
         ];
     }

--- a/Resource/template/admin/payment_status.twig
+++ b/Resource/template/admin/payment_status.twig
@@ -251,7 +251,7 @@ file that was distributed with this source code.
                             </div>
                             <div class="row justify-content-md-center mb-4">
                                 {% if pagination.totalItemCount > 0 %}
-                                    {% include "@admin/styleguide_pager.twig" with { 'pages' : pagination.paginationData, 'routes' : 'sample_payment_admin_payment_status_pageno' } %}
+                                    {% include "@admin/pager.twig" with { 'pages' : pagination.paginationData, 'routes' : 'sample_payment_admin_payment_status_pageno' } %}
                                 {% endif %}
                             </div>
                         </div>

--- a/SamplePaymentNav.php
+++ b/SamplePaymentNav.php
@@ -24,9 +24,12 @@ class SamplePaymentNav implements EccubeNav
     {
         return [
             'order' => [
-                'id' => 'sample_payment_admin_payment_status',
-                'name' => 'sample_payment.admin.nav.payment_list',
-                'url' => 'sample_payment_admin_payment_status',
+                'child' => [
+                    'sample_payment_admin_payment_status' => [
+                        'name' => 'sample_payment.admin.nav.payment_list',
+                        'url' => 'sample_payment_admin_payment_status',
+                    ],
+                ]
             ],
         ];
     }


### PR DESCRIPTION
- 本体のナビの定義の構造が変わったので対応
  - https://github.com/EC-CUBE/ec-cube/pull/3450
- ファイル名変更対応
  - `styleguide_pager.twig` -> `pager.twig'

