### PR TITLE
フォーム制御をbeta2の変更内容に追随

### DIFF
--- a/Form/Extension/CreditCardExtention.php
+++ b/Form/Extension/CreditCardExtention.php
@@ -56,15 +56,31 @@ class CreditCardExtention extends AbstractTypeExtension
         });
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
-            $Payment = $this->paymentRepository->findOneBy(['method_class' => CreditCard::class]);
+            $options = $event->getForm()->getConfig()->getOptions();
 
-            /** @var Order $data */
-            $data = $event->getData();
-            $form = $event->getForm();
+            // 注文確認->注文処理時はフォームは定義されない.
+            if ($options['skip_add_form']) {
 
-            // 支払い方法が一致しなければremove
-            if ($Payment->getId() != $data['Payment']) {
-                $form->remove('sample_payment_token');
+                // サンプル決済では使用しないが、支払い方法に応じて処理を行う場合は
+                // $event->getData()ではなく、$event->getForm()->getData()でOrderエンティティを取得できる
+
+                /** @var Order $Order */
+                $Order = $event->getForm()->getData();
+                $Order->getPayment()->getId();
+
+                return;
+            } else {
+
+                $Payment = $this->paymentRepository->findOneBy(['method_class' => CreditCard::class]);
+
+                $data = $event->getData();
+                $form = $event->getForm();
+
+                // 支払い方法が一致しなければremove
+                if ($Payment->getId() != $data['Payment']) {
+                    $form->remove('sample_payment_token');
+                }
+
             }
         });
     }

--- a/Resource/template/credit.twig
+++ b/Resource/template/credit.twig
@@ -1,38 +1,36 @@
 {#
     Shopping/index.twigに以下のスニペットを追記
-    {{ eccube_block_sample_payment_credit_form({ Order: Order, form: form }) }}
+    {{ include('@SamplePayment/credit.twig', ignore_missing=true) }}
 #}
-{% block sample_payment_credit_form %}
-    {% if Order.Payment.getMethodClass == 'Plugin\\SamplePayment\\Service\\Method\\CreditCard' %}
-        <script>
-            $(function () {
-                $('#shopping-form > div > div.ec-orderRole__summary > div > div.ec-totalBox__btn > button').on('click', function (e) {
-                    // トークン取得処理
-                    var card_no = $('#shopping_order_sample_payment_card_no').val();
-                    if (card_no == '') {
-                        alert('カード番号が入力されていません');
-                        return false;
-                    }
-                    // サーバ通信してトークンを取得
-                    var token = 'aaabbbccc123456';
+{% if Order.Payment.getMethodClass == 'Plugin\\SamplePayment\\Service\\Method\\CreditCard' %}
+    <script>
+        $(function () {
+            $('#shopping-form > div > div.ec-orderRole__summary > div > div.ec-totalBox__btn > button').on('click', function (e) {
+                // トークン取得処理
+                var card_no = $('#shopping_order_sample_payment_card_no').val();
+                if (card_no == '') {
+                    alert('カード番号が入力されていません');
+                    return false;
+                }
+                // サーバ通信してトークンを取得
+                var token = 'aaabbbccc123456';
 
-                    // hiddenにトークンをセット
-                    $('#shopping_order_sample_payment_token').val(token);
-                });
+                // hiddenにトークンをセット
+                $('#shopping_order_sample_payment_token').val(token);
             });
+        });
 
-        </script>
-        <div class="ec-orderPayment">
-            <div class="ec-rectHeading">
-                <h2>カード(暫定実装)</h2>
-            </div>
-            <div class="ec-input">
-                {# jsで取得したトークンをhiddenでサーバサイドへsubmitする. #}
-                {{ form_widget(form.sample_payment_token) }}
-
-                {# カード番号をサーバサイドへPOSTしないよう, name属性は出力しない #}
-                <input type="text" id="shopping_order_sample_payment_card_no">
-            </div>
+    </script>
+    <div class="ec-orderPayment">
+        <div class="ec-rectHeading">
+            <h2>カード(暫定実装)</h2>
         </div>
-    {% endif %}
-{% endblock %}
+        <div class="ec-input">
+            {# jsで取得したトークンをhiddenでサーバサイドへsubmitする. #}
+            {{ form_widget(form.sample_payment_token) }}
+
+            {# カード番号をサーバサイドへPOSTしないよう, name属性は出力しない #}
+            <input type="text" id="shopping_order_sample_payment_card_no">
+        </div>
+    </div>
+{% endif %}

--- a/Resource/template/credit_confirm.twig
+++ b/Resource/template/credit_confirm.twig
@@ -1,17 +1,15 @@
 {#
     Shopping/confirm.twigに以下のスニペットを追記
-    {{ eccube_block_sample_payment_credit_form_confirm({ Order: Order, form: form }) }}
+    {{ include('@SamplePayment/credit_confirm.twig', ignore_missing=true) }}
 #}
-{% block sample_payment_credit_form_confirm %}
-    {% if Order.Payment.method_class == 'Plugin\\SamplePayment\\Service\\Method\\CreditCard' %}
-        <div class="ec-orderPayment">
-            <div class="ec-rectHeading">
-                <h2>クレジットカード番号(下4桁)</h2>
-            </div>
-            <div class="ec-input">
-                {{ form_widget(form.sample_payment_token) }}
-                {{ Order.sample_payment_card_no_last4 }}
-            </div>
+{% if Order.Payment.method_class == 'Plugin\\SamplePayment\\Service\\Method\\CreditCard' %}
+    <div class="ec-orderPayment">
+        <div class="ec-rectHeading">
+            <h2>クレジットカード番号(下4桁)</h2>
         </div>
-    {% endif %}
-{% endblock %}
+        <div class="ec-input">
+            {{ form_widget(form.sample_payment_token) }}
+            {{ Order.sample_payment_card_no_last4 }}
+        </div>
+    </div>
+{% endif %}


### PR DESCRIPTION
- https://github.com/EC-CUBE/ec-cube/pull/3714 の変更にあわせて、フォームの制御処理を修正
- codeのスニペットをtwig_blockではなくincludeを使うように変更