### PR TITLE
購入確認画面でのフォーム送信が無効になるように修正

### DIFF
--- a/Form/Extension/CreditCardExtention.php
+++ b/Form/Extension/CreditCardExtention.php
@@ -41,6 +41,11 @@ class CreditCardExtention extends AbstractTypeExtension
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        // ShoppingController::checkoutから呼ばれる場合は, フォーム項目の定義をスキップする.
+        if ($options['skip_add_form']) {
+            return;
+        }
+
         $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
             /** @var Order $data */
             $form = $event->getForm();
@@ -53,20 +58,12 @@ class CreditCardExtention extends AbstractTypeExtension
         });
 
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
-            $options = $event->getForm()->getConfig()->getOptions();
+            // サンプル決済では使用しないが、支払い方法に応じて処理を行う場合は
+            // $event->getData()ではなく、$event->getForm()->getData()でOrderエンティティを取得できる
 
-            // 注文確認->注文処理時はフォームは定義されない.
-            if ($options['skip_add_form']) {
-
-                // サンプル決済では使用しないが、支払い方法に応じて処理を行う場合は
-                // $event->getData()ではなく、$event->getForm()->getData()でOrderエンティティを取得できる
-
-                /** @var Order $Order */
-                $Order = $event->getForm()->getData();
-                $Order->getPayment()->getId();
-
-                return;
-            }
+            /** @var Order $Order */
+            $Order = $event->getForm()->getData();
+            $Order->getPayment()->getId();
         });
     }
 

--- a/Resource/template/credit_confirm.twig
+++ b/Resource/template/credit_confirm.twig
@@ -8,7 +8,6 @@
             <h2>クレジットカード番号(下4桁)</h2>
         </div>
         <div class="ec-input">
-            {{ form_widget(form.sample_payment_token) }}
             {{ Order.sample_payment_card_no_last4 }}
         </div>
     </div>

--- a/Resource/template/cvs_confirm.twig
+++ b/Resource/template/cvs_confirm.twig
@@ -8,12 +8,9 @@
             <h2>コンビニ決済</h2>
         </div>
         <div class="ec-radio">
-            {{ form_widget(form.SamplePaymentCvsType, { type: 'hidden' }) }}
             {% if form.SamplePaymentCvsType.vars.data.name is defined %}
                 {{ form.SamplePaymentCvsType.vars.data.name }}
             {% endif %}
         </div>
     </div>
-{% else %}
-    {{ form_widget(form.SamplePaymentCvsType, { type: 'hidden' }) }}
 {% endif %}


### PR DESCRIPTION
購入確認画面でhtmlソースを直接変更するとその情報で受注登録できる状態となっていた。
購入確認画面ではフォームを送信しない、送信しても更新されないように変更した。